### PR TITLE
remove `-v`  in default test command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ async function run() {
     if (no_parallel) {
       addArg += ' -parallel 1';
     }
-    let tCommand = `go test -v${addArg} -coverprofile=${scopeLogsPath}/coverage.out ./...`;
+    let tCommand = `go test ${addArg} -coverprofile=${scopeLogsPath}/coverage.out ./...`;
     let bCommand = `go test -run Benchmark -bench=.`;
     if (test_command) {
       tCommand = test_command;


### PR DESCRIPTION
Verbose argument it's not recommended to run the tests. The recommended behavior is run without since if one test fails it outputs the full stdout and stderr for this particular test.